### PR TITLE
Makefile improvements and address resolution fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,20 @@ BINARY_NAME=ServiceRunner
 
 build:
 	@echo "building ${BINARY_NAME}"
-	@cd src/ && go build -o "../$(BUILD_DIR)/${BINARY_NAME}"
+	@cd src/ && go build -o "../$(BUILD_DIR)${BINARY_NAME}" ${buildargs}
 
+#
+# You can specify run arguments and build arguments using runargs and buildargs, like this:
+# make start runargs="-debug"
+# make start runargs="-debug" buildargs="-verbose"
+# make build buildargs="-verbose"
+#
 start: build
 	@echo "starting ${BINARY_NAME}"
-	@cd "./${BUILD_DIR}/${BINARY_NAME}"
+	./${BUILD_DIR}${BINARY_NAME} ${runargs}
 
 clean:
-	@echo "Cleaning all targets for mod/Actuator"
+	@echo "Cleaning all targets for ${BINARY_NAME}"
 	rm -rf $(BUILD_DIR)
 
 test:


### PR DESCRIPTION
Fixes:

- The Makefile `start` and `build` targets now support `runargs` and `buildargs` to pass flags and arguments (not really important, because this package is not run as a module)
- When a service with the name **systemmanager** registers, the ServiceRunner will not attempt to resolve the System Manager addresses from environment variables, as this is of no use (the System Manager will not connect to itself :))