### PR TITLE
Autoreplace localhost with asterisk in own output definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,11 @@ Some examples:
 
 **Service name `systemmanager` is a reserved name**
 When specifying your service name as `systemmanager` in *service.yaml*, the ServiceRunner will not attempt service registration, dependency resolving and tuning state fetching. (As the system manager cannot register with itself).
+
+**Outputs with `localhost` in their address will be rewritten**
+A service that wants to use its own outputs in its *service.yaml* file will get a rewritten version of their output address to make sure that you can use the address to listen on all interfaces (useful when using zeroMQ). This is best illustrated in this example:
+
+- **Service A** depends on **Service B**
+- **Service B** has one output, named **Output 1**, with address **tcp://localhost:1234**
+- During the dependency resolution of Service A, it will fetch **tcp://localhost:1234**, so that service A can start listening there
+  - **HOWEVER**: Service B will receive **tcp://*:1234** as its own output address, so that it can start listening on all interfaces. Notice how `localhost` was replaced with `*`

--- a/src/definition.go
+++ b/src/definition.go
@@ -90,6 +90,10 @@ func parseServiceDefinition(yamlString string) (serviceDefinition, error) {
 	}
 
 	validationError := validateServiceDefinition(serviceDefinition)
+	if validationError != nil {
+		return serviceDefinition, validationError
+	}
+
 	return serviceDefinition, validationError
 }
 

--- a/src/runner.go
+++ b/src/runner.go
@@ -77,6 +77,7 @@ func Run(main MainFunction, onTuningState TuningStateCallbackFunction) {
 	retries := flag.Int("retries", 0, "how often to retry the service if it fails")
 	serviceYamlPath := flag.String("service-yaml", "service.yaml", "path to the service definition yaml file")
 	noLiveTuning := flag.Bool("disable-live-tuning", false, "disable live tuning updates from the system manager")
+
 	flag.Parse()
 
 	// Parse the service definition


### PR DESCRIPTION
See the "important" sect. in the updated README.
This is necessary, since zmq errors on binding to localhost, instead needs `*`